### PR TITLE
[Feature] 음악 플레이어 구현 (#2)

### DIFF
--- a/MusicTestApp/Features/MusicList/MusicListView.swift
+++ b/MusicTestApp/Features/MusicList/MusicListView.swift
@@ -2,25 +2,121 @@
 //  MusicListView.swift
 //  MusicTestApp
 //
-//  음악 리스트 탭 뷰
+//  음악 리스트 탭 뷰 — 더미 데이터 + 미니 플레이어 연동
 //
 
 import SwiftUI
 
+// MARK: - 더미 데이터
+
+private extension MusicItem {
+    static let dummies: [MusicItem] = [
+        MusicItem(
+            title: "Blinding Lights",
+            artist: "The Weeknd",
+            url: URL(string: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3")!
+        ),
+        MusicItem(
+            title: "Shape of You",
+            artist: "Ed Sheeran",
+            url: URL(string: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-2.mp3")!
+        ),
+        MusicItem(
+            title: "Stay",
+            artist: "The Kid LAROI",
+            url: URL(string: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-3.mp3")!
+        ),
+        MusicItem(
+            title: "Levitating",
+            artist: "Dua Lipa",
+            url: URL(string: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-4.mp3")!
+        ),
+        MusicItem(
+            title: "Peaches",
+            artist: "Justin Bieber",
+            url: URL(string: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-5.mp3")!
+        ),
+        MusicItem(
+            title: "Good 4 U",
+            artist: "Olivia Rodrigo",
+            url: URL(string: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-6.mp3")!
+        ),
+        MusicItem(
+            title: "Montero",
+            artist: "Lil Nas X",
+            url: URL(string: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-7.mp3")!
+        ),
+        MusicItem(
+            title: "Kiss Me More",
+            artist: "Doja Cat",
+            url: URL(string: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-8.mp3")!
+        ),
+    ]
+}
+
+// MARK: - MusicListView
+
 struct MusicListView: View {
+    private let player = MusicPlayerManager.shared
+    private let tracks = MusicItem.dummies
+
     var body: some View {
-        ContentUnavailableView {
-            Label("음악 없음", systemImage: "music.note.list")
-        } description: {
-            Text("음악을 추가하면 여기에 표시됩니다.")
-        } actions: {
-            Button(action: {}) {
-                Label("음악 추가", systemImage: "plus")
-            }
-            .buttonStyle(.borderedProminent)
+        List(tracks) { item in
+            MusicRowView(item: item, isPlaying: player.currentItem == item && player.isPlaying)
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    player.play(item: item, in: tracks)
+                }
         }
+        .listStyle(.plain)
     }
 }
+
+// MARK: - 음악 행 셀
+
+private struct MusicRowView: View {
+    let item: MusicItem
+    let isPlaying: Bool
+
+    var body: some View {
+        HStack(spacing: 14) {
+            // 앨범 아트 (더미 — SF Symbol)
+            ZStack {
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.accentColor.opacity(0.15))
+                    .frame(width: 48, height: 48)
+                Image(systemName: isPlaying ? "waveform" : "music.note")
+                    .font(.title3)
+                    .foregroundStyle(Color.accentColor)
+                    .symbolEffect(.variableColor.iterative, isActive: isPlaying)
+            }
+
+            // 제목 / 아티스트
+            VStack(alignment: .leading, spacing: 3) {
+                Text(item.title)
+                    .font(.subheadline.bold())
+                    .foregroundStyle(isPlaying ? Color.accentColor : .primary)
+                    .lineLimit(1)
+                Text(item.artist)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            // 재생 중 표시
+            if isPlaying {
+                Image(systemName: "speaker.wave.2.fill")
+                    .font(.caption)
+                    .foregroundStyle(Color.accentColor)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+// MARK: - Preview
 
 #Preview {
     NavigationStack {

--- a/MusicTestApp/Navigation/MainTabView.swift
+++ b/MusicTestApp/Navigation/MainTabView.swift
@@ -3,7 +3,7 @@
 //  MusicTestApp
 //
 //  멀티플랫폼 네비게이션 루트 뷰
-//  - iOS / iPadOS : TabView (하단 탭바)
+//  - iOS / iPadOS : TabView (하단 탭바) + MiniPlayer 오버레이
 //  - macOS        : NavigationSplitView (사이드바)
 //
 
@@ -52,25 +52,42 @@ struct MainTabView: View {
     }
 }
 
-// MARK: - iOS / iPadOS TabView
+// MARK: - iOS / iPadOS TabView + MiniPlayer 오버레이
 
 #if !os(macOS)
 struct IOSTabView: View {
     @Binding var selectedTab: AppTab
+    private let player = MusicPlayerManager.shared
 
     var body: some View {
-        TabView(selection: $selectedTab) {
-            ForEach(AppTab.allCases) { tab in
-                NavigationStack {
-                    tabDestination(for: tab)
-                        .navigationTitle(tab.title)
+        ZStack(alignment: .bottom) {
+            TabView(selection: $selectedTab) {
+                ForEach(AppTab.allCases) { tab in
+                    NavigationStack {
+                        tabDestination(for: tab)
+                            .navigationTitle(tab.title)
+                    }
+                    // 미니 플레이어가 보일 때 탭바 위 여백 확보
+                    .safeAreaInset(edge: .bottom) {
+                        if player.isMiniPlayerVisible {
+                            Color.clear.frame(height: 100)
+                        }
+                    }
+                    .tabItem {
+                        Label(tab.title, systemImage: tab.systemImage)
+                    }
+                    .tag(tab)
                 }
-                .tabItem {
-                    Label(tab.title, systemImage: tab.systemImage)
-                }
-                .tag(tab)
+            }
+
+            // 미니 플레이어 — 탭바 바로 위에 오버레이
+            if player.isMiniPlayerVisible {
+                MiniPlayerView()
+                    .padding(.bottom, 50) // 탭바 높이만큼 위로
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
             }
         }
+        .animation(.spring(response: 0.35, dampingFraction: 0.8), value: player.isMiniPlayerVisible)
     }
 }
 #endif

--- a/MusicTestApp/Player/FullPlayerView.swift
+++ b/MusicTestApp/Player/FullPlayerView.swift
@@ -1,0 +1,60 @@
+//
+//  FullPlayerView.swift
+//  MusicTestApp
+//
+//  풀스크린 플레이어 — 다음 타임 개발용 Placeholder
+//
+
+import SwiftUI
+
+struct FullPlayerView: View {
+    @Environment(\.dismiss) private var dismiss
+    private let player = MusicPlayerManager.shared
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            Color(.systemBackground)
+                .ignoresSafeArea()
+
+            VStack(spacing: 24) {
+                Spacer()
+
+                Image(systemName: "music.note.tv.fill")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 120, height: 120)
+                    .foregroundStyle(.secondary)
+
+                VStack(spacing: 8) {
+                    Text(player.currentItem?.title ?? "재생 중인 곡 없음")
+                        .font(.title2.bold())
+                    Text(player.currentItem?.artist ?? "")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+
+                Text("풀스크린 플레이어는 다음 버전에서 개발됩니다.")
+                    .font(.footnote)
+                    .foregroundStyle(.tertiary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 40)
+
+                Spacer()
+            }
+
+            // 닫기 버튼
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "chevron.down.circle.fill")
+                    .font(.title)
+                    .foregroundStyle(.secondary)
+                    .padding()
+            }
+        }
+    }
+}
+
+#Preview {
+    FullPlayerView()
+}

--- a/MusicTestApp/Player/MiniPlayerView.swift
+++ b/MusicTestApp/Player/MiniPlayerView.swift
@@ -1,0 +1,166 @@
+//
+//  MiniPlayerView.swift
+//  MusicTestApp
+//
+//  탭바 위에 고정되는 미니 플레이어
+//  - 이전곡 / -5초 / 재생·정지 / +5초 / 다음곡 버튼
+//  - 위로 드래그하면 FullPlayerView 시트로 전환
+//
+
+import SwiftUI
+
+struct MiniPlayerView: View {
+
+    private let player = MusicPlayerManager.shared
+
+    // MARK: 드래그 상태
+    @State private var dragOffset: CGFloat = 0
+    @State private var showFullPlayer: Bool = false
+
+    // 드래그 임계값: 이 이상 위로 당기면 풀플레이어 오픈
+    private let dragThreshold: CGFloat = -60
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // 드래그 핸들
+            Capsule()
+                .fill(Color.secondary.opacity(0.4))
+                .frame(width: 36, height: 4)
+                .padding(.top, 8)
+
+            // 곡 정보 + 컨트롤
+            VStack(spacing: 6) {
+                // 곡 제목 / 아티스트
+                VStack(spacing: 2) {
+                    Text(player.currentItem?.title ?? "재생 중인 곡 없음")
+                        .font(.subheadline.bold())
+                        .lineLimit(1)
+                    Text(player.currentItem?.artist ?? "")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                .padding(.top, 4)
+
+                // 재생 진행바
+                ProgressView(value: progressValue)
+                    .tint(.primary)
+                    .padding(.horizontal, 16)
+
+                // 컨트롤 버튼
+                HStack(spacing: 0) {
+                    // 이전 곡
+                    controlButton(
+                        icon: "backward.end.fill",
+                        size: 20
+                    ) {
+                        player.playPrevious()
+                    }
+
+                    Spacer()
+
+                    // -5초
+                    controlButton(
+                        icon: "gobackward.5",
+                        size: 22
+                    ) {
+                        player.seek(by: -5)
+                    }
+
+                    Spacer()
+
+                    // 재생 / 정지
+                    controlButton(
+                        icon: player.isPlaying ? "pause.circle.fill" : "play.circle.fill",
+                        size: 40,
+                        isPrimary: true
+                    ) {
+                        player.togglePlayPause()
+                    }
+
+                    Spacer()
+
+                    // +5초
+                    controlButton(
+                        icon: "goforward.5",
+                        size: 22
+                    ) {
+                        player.seek(by: 5)
+                    }
+
+                    Spacer()
+
+                    // 다음 곡
+                    controlButton(
+                        icon: "forward.end.fill",
+                        size: 20
+                    ) {
+                        player.playNext()
+                    }
+                }
+                .padding(.horizontal, 32)
+                .padding(.bottom, 8)
+            }
+        }
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .shadow(color: .black.opacity(0.12), radius: 8, y: -2)
+        .offset(y: dragOffset)
+        // 드래그 제스처
+        .gesture(
+            DragGesture(minimumDistance: 10)
+                .onChanged { value in
+                    // 위로만 드래그 허용
+                    if value.translation.height < 0 {
+                        dragOffset = value.translation.height * 0.4
+                    }
+                }
+                .onEnded { value in
+                    if value.translation.height < dragThreshold {
+                        // 임계값 초과 → 풀플레이어 오픈
+                        showFullPlayer = true
+                    }
+                    withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+                        dragOffset = 0
+                    }
+                }
+        )
+        .animation(.spring(response: 0.3, dampingFraction: 0.8), value: player.isPlaying)
+        .sheet(isPresented: $showFullPlayer) {
+            FullPlayerView()
+        }
+        .padding(.horizontal, 8)
+    }
+
+    // MARK: - 진행바 값 (0.0 ~ 1.0)
+    private var progressValue: Double {
+        guard player.duration > 0 else { return 0 }
+        return player.currentTime / player.duration
+    }
+
+    // MARK: - 버튼 빌더
+    @ViewBuilder
+    private func controlButton(
+        icon: String,
+        size: CGFloat,
+        isPrimary: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .resizable()
+                .scaledToFit()
+                .frame(width: size, height: size)
+                .foregroundStyle(isPrimary ? .primary : .secondary)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    VStack {
+        Spacer()
+        MiniPlayerView()
+    }
+    .background(Color(.systemGroupedBackground))
+}

--- a/MusicTestApp/Player/MusicPlayerManager.swift
+++ b/MusicTestApp/Player/MusicPlayerManager.swift
@@ -1,0 +1,147 @@
+//
+//  MusicPlayerManager.swift
+//  MusicTestApp
+//
+//  AVFoundation 기반 재생 엔진 + 전역 상태 관리
+//
+
+import AVFoundation
+import SwiftUI
+import Observation
+
+// MARK: - 음악 아이템 모델
+
+struct MusicItem: Identifiable, Equatable {
+    let id: UUID
+    let title: String
+    let artist: String
+    let url: URL
+
+    init(id: UUID = UUID(), title: String, artist: String, url: URL) {
+        self.id = id
+        self.title = title
+        self.artist = artist
+        self.url = url
+    }
+}
+
+// MARK: - 플레이어 매니저
+
+@Observable
+final class MusicPlayerManager {
+
+    // MARK: 공유 인스턴스
+    static let shared = MusicPlayerManager()
+
+    // MARK: 재생 상태
+    var currentItem: MusicItem? = nil
+    var isPlaying: Bool = false
+    var currentTime: TimeInterval = 0
+    var duration: TimeInterval = 0
+    var queue: [MusicItem] = []
+    var currentIndex: Int = 0
+
+    // MARK: 미니 플레이어 표시 여부
+    var isMiniPlayerVisible: Bool = false
+
+    // MARK: Private
+    private var player: AVPlayer?
+    private var timeObserver: Any?
+
+    private init() {}
+
+    // MARK: - 재생 제어
+
+    /// 새 곡 재생
+    func play(item: MusicItem, in queue: [MusicItem] = []) {
+        self.queue = queue.isEmpty ? [item] : queue
+        self.currentIndex = self.queue.firstIndex(of: item) ?? 0
+        load(item: item)
+        player?.play()
+        isPlaying = true
+        isMiniPlayerVisible = true
+    }
+
+    /// 재생 / 일시정지 토글
+    func togglePlayPause() {
+        guard player != nil else { return }
+        if isPlaying {
+            player?.pause()
+        } else {
+            player?.play()
+        }
+        isPlaying.toggle()
+    }
+
+    /// 이전 곡
+    func playPrevious() {
+        guard !queue.isEmpty else { return }
+        currentIndex = max(currentIndex - 1, 0)
+        load(item: queue[currentIndex])
+        player?.play()
+        isPlaying = true
+    }
+
+    /// 다음 곡
+    func playNext() {
+        guard !queue.isEmpty else { return }
+        currentIndex = min(currentIndex + 1, queue.count - 1)
+        load(item: queue[currentIndex])
+        player?.play()
+        isPlaying = true
+    }
+
+    /// n초 탐색 (양수: 앞으로, 음수: 뒤로)
+    func seek(by seconds: TimeInterval) {
+        let target = max(0, min(currentTime + seconds, duration))
+        let time = CMTime(seconds: target, preferredTimescale: 600)
+        player?.seek(to: time)
+        currentTime = target
+    }
+
+    /// 특정 위치로 탐색
+    func seek(to time: TimeInterval) {
+        let clamped = max(0, min(time, duration))
+        let cmTime = CMTime(seconds: clamped, preferredTimescale: 600)
+        player?.seek(to: cmTime)
+        currentTime = clamped
+    }
+
+    // MARK: - Private
+
+    private func load(item: MusicItem) {
+        removeTimeObserver()
+        currentItem = item
+
+        let playerItem = AVPlayerItem(url: item.url)
+        player = AVPlayer(playerItem: playerItem)
+
+        // 재생 시간 옵저버
+        timeObserver = player?.addPeriodicTimeObserver(
+            forInterval: CMTime(seconds: 0.5, preferredTimescale: 600),
+            queue: .main
+        ) { [weak self] time in
+            self?.currentTime = time.seconds
+            if let duration = self?.player?.currentItem?.duration.seconds,
+               duration.isFinite {
+                self?.duration = duration
+            }
+        }
+
+        // 곡 종료 시 다음 곡
+        NotificationCenter.default.addObserver(
+            forName: .AVPlayerItemDidPlayToEndTime,
+            object: playerItem,
+            queue: .main
+        ) { [weak self] _ in
+            self?.playNext()
+        }
+    }
+
+    private func removeTimeObserver() {
+        if let observer = timeObserver {
+            player?.removeTimeObserver(observer)
+            timeObserver = nil
+        }
+    }
+}


### PR DESCRIPTION
## 개요
탭바 위에 고정되는 미니 플레이어와 드래그로 끌어올리는 풀스크린 플레이어 틀을 구현합니다.

## 변경 파일

| 파일 | 변경 유형 | 설명 |
|------|---------|------|
| `Player/MusicPlayerManager.swift` | 신규 | AVFoundation 재생 엔진 + `@Observable` 전역 상태 관리 |
| `Player/MiniPlayerView.swift` | 신규 | 탭바 위 미니 플레이어 UI + 드래그 제스처 |
| `Player/FullPlayerView.swift` | 신규 | 풀스크린 플레이어 Placeholder (다음 버전 개발 예정) |
| `Navigation/MainTabView.swift` | 수정 | 미니 플레이어 오버레이 연동 |

## 구현 내용

### MiniPlayerView
- 탭바 바로 위에 `ultraThinMaterial` 배경으로 고정 표시
- 컨트롤 버튼: **이전곡 / -5초 / 재생·정지 / +5초 / 다음곡**
- 재생 진행바 (`ProgressView`)
- 위로 드래그 시 `FullPlayerView` 시트로 전환 (임계값: 60pt)

### MusicPlayerManager
- `AVFoundation` 기반 오디오 재생 엔진
- `@Observable`로 전역 상태 관리 (재생 여부, 현재 곡, 진행 시간 등)
- 재생 / 정지 / 이전곡 / 다음곡 / seek(by:) 지원
- 곡 종료 시 자동으로 다음 곡 재생

### FullPlayerView
- 다음 타임 개발을 위한 Placeholder UI
- 현재 재생 중인 곡 정보 표시
- 아래로 내리기 버튼으로 dismiss

## 연관 이슈
Closes #2